### PR TITLE
feat: Make `Reporter` more idiomatic

### DIFF
--- a/crates/yab/src/bencher.rs
+++ b/crates/yab/src/bencher.rs
@@ -11,11 +11,17 @@ use crate::{
     BenchmarkId, CachegrindStats, Capture,
 };
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum BenchMode {
+/// Mode in which the bencher is currently executing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum BenchMode {
+    /// Testing the benchmark code. Enabled by running benchmarks via `cargo test`.
     Test,
+    /// Collecting benchmark data (i.e., the main / default mode).
     Bench,
+    /// Listing benchmark names. Enabled by specifying `--list` command-line arg.
     List,
+    /// Printing benchmark results collected during previous runs. Enabled by specifying `--print` command-line arg.
     PrintResults,
 }
 
@@ -45,6 +51,15 @@ impl BenchModeData {
             },
             BenchMode::List => Self::List,
             BenchMode::PrintResults => Self::PrintResults,
+        }
+    }
+
+    fn mode(&self) -> BenchMode {
+        match self {
+            Self::Test { .. } => BenchMode::Test,
+            Self::Bench { .. } => BenchMode::Bench,
+            Self::List => BenchMode::List,
+            Self::PrintResults => BenchMode::PrintResults,
         }
     }
 }
@@ -337,12 +352,21 @@ impl Default for Bencher {
 }
 
 impl Bencher {
+    /// Adds a reporter to the bencher. Beware that bencher initialization may skew benchmark results.
     #[doc(hidden)] // not stable yet
     pub fn add_reporter(&mut self, reporter: impl Reporter + 'static) -> &mut Self {
         if let BencherInner::Main(bencher) = &mut self.inner {
             bencher.reporter.0.push(Box::new(reporter));
         }
         self
+    }
+
+    /// Gets the benchmarking mode.
+    pub fn mode(&self) -> BenchMode {
+        match &self.inner {
+            BencherInner::Main(bencher) => bencher.mode.mode(),
+            BencherInner::Cachegrind(_) => BenchMode::Bench,
+        }
     }
 
     /// Benchmarks a single function. Dropping the output won't be included into the captured stats.

--- a/crates/yab/src/bencher.rs
+++ b/crates/yab/src/bencher.rs
@@ -79,6 +79,7 @@ impl Drop for MainBencher {
             }
             _ => { /* no special handling required */ }
         }
+        mem::take(&mut self.reporter).ok_all();
     }
 }
 

--- a/crates/yab/src/lib.rs
+++ b/crates/yab/src/lib.rs
@@ -131,7 +131,7 @@
 pub use std::hint::black_box;
 
 pub use crate::{
-    bencher::Bencher,
+    bencher::{BenchMode, Bencher},
     cachegrind::{
         AccessSummary, CachegrindDataPoint, CachegrindStats, Capture, CaptureGuard,
         FullCachegrindStats,

--- a/crates/yab/src/reporter/mod.rs
+++ b/crates/yab/src/reporter/mod.rs
@@ -29,6 +29,7 @@ pub struct BenchmarkOutput {
 #[allow(unused_variables)]
 pub trait Reporter: fmt::Debug {
     /// Reports a (non-recoverable) error not related to a particular benchmark.
+    /// This is mutually exclusive with [`Self::ok()`].
     ///
     /// The default implementation does nothing.
     fn error(&mut self, error: &dyn fmt::Display) {
@@ -43,6 +44,14 @@ pub trait Reporter: fmt::Debug {
     /// Initializes a benchmark with the specified ID. Note that the benchmark isn't necessarily
     /// immediately started; the start will be signaled separately via [`BenchmarkReporter::start_execution()`].
     fn new_benchmark(&mut self, id: &BenchmarkId) -> Box<dyn BenchmarkReporter>;
+
+    /// Signals to the reporter that processing tests / benchmarks has successfully completed.
+    /// This is mutually exclusive with [`Self::error()`].
+    ///
+    /// The default implementation does nothing.
+    fn ok(self: Box<Self>) {
+        // do nothing
+    }
 }
 
 /// Reporter of events for a single benchmark run in the test mode.

--- a/crates/yab/src/reporter/seq.rs
+++ b/crates/yab/src/reporter/seq.rs
@@ -5,8 +5,16 @@ use std::{any::Any, fmt::Display};
 use super::{BenchmarkOutput, BenchmarkReporter, Reporter, TestReporter};
 use crate::{BenchmarkId, CachegrindStats};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct SeqReporter(pub Vec<Box<dyn Reporter>>);
+
+impl SeqReporter {
+    pub fn ok_all(self) {
+        for reporter in self.0 {
+            reporter.ok();
+        }
+    }
+}
 
 impl Reporter for SeqReporter {
     fn error(&mut self, error: &dyn Display) {

--- a/e2e-tests/src/exporter.rs
+++ b/e2e-tests/src/exporter.rs
@@ -32,10 +32,8 @@ impl Reporter for BenchmarkExporter {
 
         Box::new(Entry(self.outputs.clone(), id.to_string()))
     }
-}
 
-impl Drop for BenchmarkExporter {
-    fn drop(&mut self) {
+    fn ok(self: Box<Self>) {
         let Ok(out_path) = env::var(EXPORTER_OUTPUT_VAR) else {
             return;
         };


### PR DESCRIPTION
## What?

Adds the `Reporter::ok()` method with a no-op implementation called after all benchmarks / tests are complete.

## Why?

Makes `Reporter` more feature-complete and allows to avoid implementing this logic via `Drop`.
