### PR TITLE
fix: Fix threshold parsing

### DIFF
--- a/crates/yab/src/options.rs
+++ b/crates/yab/src/options.rs
@@ -124,7 +124,6 @@ pub(crate) struct BenchOptions {
     #[arg(
         long,
         env = "CACHEGRIND_REGRESSION_THRESHOLD",
-        requires = "baseline",
         value_name = "RATIO",
         value_parser = f64_ratio,
         default_value_t = 0.05

--- a/e2e-tests/tests/integration.rs
+++ b/e2e-tests/tests/integration.rs
@@ -574,3 +574,13 @@ fn comparing_public_baselines_with_threshold() {
         .unwrap();
     assert_eq!(error, "1 bench has regressed by >1.0%:");
 }
+
+#[test]
+fn threshold_is_ignored_in_test_mode() {
+    let output = Command::new(EXE_PATH)
+        .env("CACHEGRIND_REGRESSION_THRESHOLD", "1%")
+        .output()
+        .expect("failed running benches");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(output.status.success(), "{stderr}");
+}


### PR DESCRIPTION
## What?

Fixes regression threshold parsing.

## Why?

Currently, if the threshold is set via the env var, it'll lead to the benchmark panicking in the test mode.
